### PR TITLE
Connect to autopr-engine container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,10 +3,13 @@
 FROM python:3.13-slim AS builder
 
 # Set environment variables
+# POETRY_VIRTUALENVS_CREATE=false ensures packages install to site-packages
+# rather than a virtual environment, making them available in production stage
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     PIP_NO_CACHE_DIR=1 \
-    PIP_DISABLE_PIP_VERSION_CHECK=1
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    POETRY_VIRTUALENVS_CREATE=false
 
 # Install system dependencies for building
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
Set POETRY_VIRTUALENVS_CREATE=false in the builder stage to ensure Poetry installs packages to the system site-packages directory instead of a virtual environment. This fixes the ModuleNotFoundError for yaml when the production stage copies dependencies from the builder's site-packages.

### ➕ What does this PR do?
<!-- concise summary -->

### 🔨 Changes
- [ ] Feature / enhancement
- [ ] Bug fix
- [ ] Chore / refactor

### ✅ Checklist
- [ ] Tests added/updated
- [ ] Docs updated (or NA)
- [ ] No secrets in diff
- [ ] Linked to issue #____
- [ ] Screenshots / GIF added (UI changes)

### 🗒 Notes for reviewer
<!-- optional -->
